### PR TITLE
Adds a property inversion_count, the number of pairs in the input which are in the opposite order in the output

### DIFF
--- a/permutation.py
+++ b/permutation.py
@@ -498,6 +498,22 @@ class Permutation(object):
             out[self(i+1)-1] = xs[i]
         return tuple(out)
 
+    def inversion_number(self):
+        """
+        Calculate the `Inversion number`_ of the permutation
+        This is the number of pairs of numbers which are in the opposite order
+        after applying the permutation.
+        This is also the Kendall tau distance from the identity permutation.
+        This is also the sum of the terms in the lehmer code.
+
+
+        .. _Inversion number: https://en.wikipedia.org/wiki/Inversion_(discrete_mathematics)#Inversion_number>
+
+        :return: the number of inversions in the permutation
+        :rtype: int
+        """
+        return sum(to_factorial_base(self.lehmer(self.degree)))
+
 
 def lcm(x,y):
     """ Calculate the least common multiple of ``x`` and ``y`` """

--- a/permutation.py
+++ b/permutation.py
@@ -507,7 +507,6 @@ class Permutation(object):
         This is also the Kendall tau distance from the identity permutation.
         This is also the sum of the terms in the lehmer code.
 
-
         .. _Inversion number: https://en.wikipedia.org/wiki/Inversion_(discrete_mathematics)#Inversion_number>
 
         :return: the number of inversions in the permutation

--- a/permutation.py
+++ b/permutation.py
@@ -498,6 +498,7 @@ class Permutation(object):
             out[self(i+1)-1] = xs[i]
         return tuple(out)
 
+    @property
     def inversion_number(self):
         """
         Calculate the `Inversion number`_ of the permutation

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -4,26 +4,26 @@ from   permutation import Permutation
 
 PermData = namedtuple(
     'PermData',
-    'p degree order even sign bool mod_lehmer cycles str image image6 permuted',
+    'p degree order even sign bool mod_lehmer inversion_number cycles str image image6 permuted',
 )
 
 PERMUTATIONS = [
-    PermData(Permutation(),            0, 1, True,   1, False,   0, [],                  '1',               (),            (1,2,3,4,5,6), ()),
-    PermData(Permutation(2,1),         2, 2, False, -1, True,    1, [(1,2)],             '(1 2)',           (2,1),         (2,1,3,4,5,6), (2,1)),
-    PermData(Permutation(1,3,2),       3, 2, False, -1, True,    2, [(2,3)],             '(2 3)',           (1,3,2),       (1,3,2,4,5,6), (1,3,2)),
-    PermData(Permutation(3,1,2),       3, 3, True,   1, True,    3, [(1,3,2)],           '(1 3 2)',         (3,1,2),       (3,1,2,4,5,6), (2,3,1)),
-    PermData(Permutation(2,3,1),       3, 3, True,   1, True,    4, [(1,2,3)],           '(1 2 3)',         (2,3,1),       (2,3,1,4,5,6), (3,1,2)),
-    PermData(Permutation(3,2,1),       3, 2, False, -1, True,    5, [(1,3)],             '(1 3)',           (3,2,1),       (3,2,1,4,5,6), (3,2,1)),
-    PermData(Permutation(1,2,4,3),     4, 2, False, -1, True,    6, [(3,4)],             '(3 4)',           (1,2,4,3),     (1,2,4,3,5,6), (1,2,4,3)),
-    PermData(Permutation(2,1,4,3),     4, 2, True,   1, True,    7, [(1,2),(3,4)],       '(1 2)(3 4)',      (2,1,4,3),     (2,1,4,3,5,6), (2,1,4,3)),
-    PermData(Permutation(2,3,4,1),     4, 4, False, -1, True,   18, [(1,2,3,4)],         '(1 2 3 4)',       (2,3,4,1),     (2,3,4,1,5,6), (4,1,2,3)),
-    PermData(Permutation(2,3,1,5,4),   5, 6, False, -1, True,   28, [(1,2,3),(4,5)],     '(1 2 3)(4 5)',    (2,3,1,5,4),   (2,3,1,5,4,6), (3,1,2,5,4)),
-    PermData(Permutation(2,3,4,5,1),   5, 5, True,   1, True,   96, [(1,2,3,4,5)],       '(1 2 3 4 5)',     (2,3,4,5,1),   (2,3,4,5,1,6), (5,1,2,3,4)),
-    PermData(Permutation(5,4,3,2,1),   5, 2, True,   1, True,  119, [(1,5),(2,4)],       '(1 5)(2 4)',      (5,4,3,2,1),   (5,4,3,2,1,6), (5,4,3,2,1)),
-    PermData(Permutation(2,1,4,3,6,5), 6, 2, False, -1, True,  127, [(1,2),(3,4),(5,6)], '(1 2)(3 4)(5 6)', (2,1,4,3,6,5), (2,1,4,3,6,5), (2,1,4,3,6,5)),
-    PermData(Permutation(2,3,4,1,6,5), 6, 4, True,   1, True,  138, [(1,2,3,4),(5,6)],   '(1 2 3 4)(5 6)',  (2,3,4,1,6,5), (2,3,4,1,6,5), (4,1,2,3,6,5)),
-    PermData(Permutation(2,3,1,5,6,4), 6, 3, True,   1, True,  244, [(1,2,3),(4,5,6)],   '(1 2 3)(4 5 6)',  (2,3,1,5,6,4), (2,3,1,5,6,4), (3,1,2,6,4,5)),
-    PermData(Permutation(2,3,4,5,6,1), 6, 6, False, -1, True,  600, [(1,2,3,4,5,6)],     '(1 2 3 4 5 6)',   (2,3,4,5,6,1), (2,3,4,5,6,1), (6,1,2,3,4,5)),
+    PermData(Permutation(),            0, 1, True,   1, False,   0,     0, [],                  '1',               (),            (1,2,3,4,5,6), ()),
+    PermData(Permutation(2,1),         2, 2, False, -1, True,    1,     1, [(1,2)],             '(1 2)',           (2,1),         (2,1,3,4,5,6), (2,1)),
+    PermData(Permutation(1,3,2),       3, 2, False, -1, True,    2,     1, [(2,3)],             '(2 3)',           (1,3,2),       (1,3,2,4,5,6), (1,3,2)),
+    PermData(Permutation(3,1,2),       3, 3, True,   1, True,    3,     2, [(1,3,2)],           '(1 3 2)',         (3,1,2),       (3,1,2,4,5,6), (2,3,1)),
+    PermData(Permutation(2,3,1),       3, 3, True,   1, True,    4,     2, [(1,2,3)],           '(1 2 3)',         (2,3,1),       (2,3,1,4,5,6), (3,1,2)),
+    PermData(Permutation(3,2,1),       3, 2, False, -1, True,    5,     3, [(1,3)],             '(1 3)',           (3,2,1),       (3,2,1,4,5,6), (3,2,1)),
+    PermData(Permutation(1,2,4,3),     4, 2, False, -1, True,    6,     1, [(3,4)],             '(3 4)',           (1,2,4,3),     (1,2,4,3,5,6), (1,2,4,3)),
+    PermData(Permutation(2,1,4,3),     4, 2, True,   1, True,    7,     2, [(1,2),(3,4)],       '(1 2)(3 4)',      (2,1,4,3),     (2,1,4,3,5,6), (2,1,4,3)),
+    PermData(Permutation(2,3,4,1),     4, 4, False, -1, True,   18,     3, [(1,2,3,4)],         '(1 2 3 4)',       (2,3,4,1),     (2,3,4,1,5,6), (4,1,2,3)),
+    PermData(Permutation(2,3,1,5,4),   5, 6, False, -1, True,   28,     3, [(1,2,3),(4,5)],     '(1 2 3)(4 5)',    (2,3,1,5,4),   (2,3,1,5,4,6), (3,1,2,5,4)),
+    PermData(Permutation(2,3,4,5,1),   5, 5, True,   1, True,   96,     4, [(1,2,3,4,5)],       '(1 2 3 4 5)',     (2,3,4,5,1),   (2,3,4,5,1,6), (5,1,2,3,4)),
+    PermData(Permutation(5,4,3,2,1),   5, 2, True,   1, True,  119,    10, [(1,5),(2,4)],       '(1 5)(2 4)',      (5,4,3,2,1),   (5,4,3,2,1,6), (5,4,3,2,1)),
+    PermData(Permutation(2,1,4,3,6,5), 6, 2, False, -1, True,  127,     3, [(1,2),(3,4),(5,6)], '(1 2)(3 4)(5 6)', (2,1,4,3,6,5), (2,1,4,3,6,5), (2,1,4,3,6,5)),
+    PermData(Permutation(2,3,4,1,6,5), 6, 4, True,   1, True,  138,     4, [(1,2,3,4),(5,6)],   '(1 2 3 4)(5 6)',  (2,3,4,1,6,5), (2,3,4,1,6,5), (4,1,2,3,6,5)),
+    PermData(Permutation(2,3,1,5,6,4), 6, 3, True,   1, True,  244,     4, [(1,2,3),(4,5,6)],   '(1 2 3)(4 5 6)',  (2,3,1,5,6,4), (2,3,1,5,6,4), (3,1,2,6,4,5)),
+    PermData(Permutation(2,3,4,5,6,1), 6, 6, False, -1, True,  600,     5, [(1,2,3,4,5,6)],     '(1 2 3 4 5 6)',   (2,3,4,5,6,1), (2,3,4,5,6,1), (6,1,2,3,4,5)),
 ]
 
 @pytest.mark.parametrize('p,degree', [(pd.p, pd.degree) for pd in PERMUTATIONS])
@@ -107,5 +107,9 @@ def test_permute(p, permuted):
 def test_bad_permute(p, degree):
     with pytest.raises(ValueError):
         p.permute(range(1, p.degree))
+
+@pytest.mark.parametrize('p,inversion_number', [(d.p, d.inversion_number) for d in PERMUTATIONS])
+def test_inversion_number(p, inversion_number):
+    assert p.inversion_number == inversion_number
 
 # vim:set nowrap:


### PR DESCRIPTION
I think this is the first time I've made a pull request like this, so please accept my apologies if I've done any of this wrong. Also, if you aren't accepting PRs, I understand.

I wrote this method because I had use for it, and thought it might be good to include.

I've tested this with tox, but I don't have all the versions of python installed that the file it set up to use, so I have not tested it with those. I believe it says that all the code I added is covered (I am not familiar with tox; installed it in order to make this PR).

The way I implemented this method may be a little inefficient in that it calls the lehmer method and then undoes the last step with the factorial base. If you would prefer I implement it differently (e.g. by just iterating through the list part, as the clearest way from the definition, or by copying in the code from the lehmer method except for the factorial base encoding at the end) I would be happy to do so.

I think I formatted the docstring for the method correctly, but I am not certain.

Regardless of whether you accept this PR, I want to thank you for making this library.

Cheers! (and a belated happy new year!)